### PR TITLE
replace timeago.js with react-timeago

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "react-redux": "^5.0.7",
     "react-scripts": "1.1.5",
     "react-test-renderer": "^16.5.2",
+    "react-timeago": "^4.1.9",
     "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "styled-components": "^3.4.9",
-    "timeago.js": "^4.0.0-beta.1",
     "url": "^0.11.0"
   },
   "scripts": {

--- a/src/components/ListItem/index.js
+++ b/src/components/ListItem/index.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Timeago from 'timeago.js';
+import TimeAgo from 'react-timeago';
 import getSiteHostname from 'utils/getSiteHostname';
 import getArticleLink, { HN_USER, HN_ITEM } from 'utils/getArticleLink';
 
 import { Item, Title, Host, ExernalLink, Description, CommentLink } from './styles';
-
-const timeago = Timeago();
 
 const ListItem = ({ by, kids = [], score, url, title, id, type, time }) => {
   const site = getSiteHostname(url) || 'news.ycombinator.com';
@@ -25,7 +23,7 @@ const ListItem = ({ by, kids = [], score, url, title, id, type, time }) => {
         <CommentLink href={`${HN_USER}${by}`} rel="nofollow noreferrer noopener" target="_blank">
           {by}
         </CommentLink>{' '}
-        {timeago.format(new Date(time * 1000).toISOString())} {' | '}
+        <TimeAgo date={new Date(time * 1000).toISOString()} />{' | '}
         <CommentLink href={commentUrl} rel="nofollow noreferrer noopener" target="_blank">
           {kids.length} Comments
         </CommentLink>


### PR DESCRIPTION
I wasn't able to get the app working from a fresh checkout and 'yarn install' from HEAD.  It was failing to initialize the timeago object.  This is with node 11.3.0.  

Replacing timestamp.js with the (more idiomatic, IMHO) react-timeago NPM made everything work.